### PR TITLE
Disable auto-revert-mode and auto-revert-tail-mode for all buffers

### DIFF
--- a/vc-defer.el
+++ b/vc-defer.el
@@ -309,10 +309,9 @@ global auto reverts back on, use \\[global-auto-revert-mode]."
     ;; are very intrusive in the trace output.
     (global-auto-revert-mode 0)
     (dolist (buffer (buffer-list))
-      (if auto-revert-mode
-          (auto-revert-mode -1))
-      (if auto-revert-tail-mode
-          (auto-revert-tail-mode -1)))
+      (with-current-buffer buffer
+        (auto-revert-mode -1)
+        (auto-revert-tail-mode -1)))
     (dolist (func
              '(after-find-file
                ;; auto-revert-handler is quite noisy, so do not trace it


### PR DESCRIPTION
And suppress byte-compile warnings

```
In vc-defer--trace:
vc-defer.el:312:11:Warning: reference to free variable ‘auto-revert-mode’
vc-defer.el:314:11:Warning: reference to free variable ‘auto-revert-tail-mode’
```